### PR TITLE
PRO-5835: Updated to handle quotes in address using caveat postcode lookup

### DIFF
--- a/app/components/string-utils.js
+++ b/app/components/string-utils.js
@@ -4,7 +4,7 @@ const {capitalize} = require('lodash');
 
 const updateLookupFormattedAddress = (formattedAddress, postcode) => {
     const postcodeUpdated = postcode.replace(/[A-Z]+/gi, capitalize);
-    formattedAddress = formattedAddress.replace(/[A-Z]+/gi, capitalize);
+    formattedAddress = formattedAddress.replace(/[A-Z]+('[A-Z])*/gi, capitalize);
     formattedAddress = formattedAddress.replace(postcodeUpdated, postcode);
     formattedAddress = formattedAddress.replace(/(^|,)(\s*)([0-9-.]+[A-Z]*),/gi, '$1$2$3');
     formattedAddress = formattedAddress.replace(/\s*,\s*/g, ',');

--- a/test/unit/testStringUtils.js
+++ b/test/unit/testStringUtils.js
@@ -15,6 +15,10 @@ const DASHES_AND_DOTS_NUMBER_TEST_POSTCODE_1 = 'SW1H 9AJ';
 const DASHES_AND_DOTS_NUMBER_TEST_SOURCE_FORMAT_1 = '1-9, CONFERENCE ROOM, 10.3, PETTY FRANCE, LONDON, SW1H 9AJ';
 const DASHES_AND_DOTS_NUMBER_TEST_UPDATED_FORMAT_1 = '1-9 Conference Room,10.3 Petty France,London,SW1H 9AJ';
 
+const APOSTROPHE_NAME_TEST_POSTCODE_1 = 'SW1A 2BJ';
+const APOSTROPHE_NAME_TEST_SOURCE_FORMAT_1 = 'IVY LODGE, ST. JAMES\'S PARK, LONDON, SW1A 2BJ';
+const APOSTROPHE_NAME_TEST_UPDATED_FORMAT_1 = 'Ivy Lodge,St. James\'s Park,London,SW1A 2BJ';
+
 describe('updateLookupFormattedAddress()', () => {
 
     it('should produce the correct use of alphanumeric characters', (done) => {
@@ -35,6 +39,13 @@ describe('updateLookupFormattedAddress()', () => {
         const output = stringUtils
             .updateLookupFormattedAddress(DASHES_AND_DOTS_NUMBER_TEST_SOURCE_FORMAT_1, DASHES_AND_DOTS_NUMBER_TEST_POSTCODE_1);
         expect(output).to.equal(DASHES_AND_DOTS_NUMBER_TEST_UPDATED_FORMAT_1);
+        done();
+    });
+
+    it('should produce the correct capitilisation using an apostrophe', (done) => {
+        const output = stringUtils
+            .updateLookupFormattedAddress(APOSTROPHE_NAME_TEST_SOURCE_FORMAT_1, APOSTROPHE_NAME_TEST_POSTCODE_1);
+        expect(output).to.equal(APOSTROPHE_NAME_TEST_UPDATED_FORMAT_1);
         done();
     });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5835

### Change description ###
Change to include a quote+chars as part of a word so that capitilisation works correctly. An example of this would be postcode SW1A 2BJ which returns "James'S Park" instead of "James's Park".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
