### PR TITLE
fix redis password mapping

### DIFF
--- a/app/setupSecrets.js
+++ b/app/setupSecrets.js
@@ -9,7 +9,7 @@ const setSecret = (secretPath, configPath) => {
 
 const setupSecrets = () => {
     if (config.has('secrets.probate')) {
-        setSecret('secrets.probate.caveats-fe-redis-access-key', 'redis.secret');
+        setSecret('secrets.probate.caveats-fe-redis-access-key', 'redis.password');
         setSecret('secrets.probate.idam-s2s-secret', 'idam.service_key');
         setSecret('secrets.probate.ccidam-idam-api-secrets-probate', 'idam.probate_oauth2_secret');
         setSecret('secrets.probate.postcode-service-url', 'services.postcode.serviceUrl');

--- a/test/unit/testSetupSecrets.js
+++ b/test/unit/testSetupSecrets.js
@@ -26,7 +26,7 @@ describe(modulePath, () => {
                 {config: mockConfig});
             setupSecrets();
 
-            expect(mockConfig.redis.secret)
+            expect(mockConfig.redis.password)
                 .to.equal(mockConfig.secrets.probate['caveats-fe-redis-access-key']);
             expect(mockConfig.idam.service_key)
                 .to.equal(mockConfig.secrets.probate['idam-s2s-secret']);
@@ -42,7 +42,7 @@ describe(modulePath, () => {
                 {config: mockConfig});
             setupSecrets();
 
-            expect(mockConfig.redis.secret)
+            expect(mockConfig.redis.password)
                 .to.equal('OVERWRITE_THIS');
         });
 
@@ -56,7 +56,7 @@ describe(modulePath, () => {
                 {config: mockConfig});
             setupSecrets();
 
-            expect(mockConfig.redis.secret)
+            expect(mockConfig.redis.password)
                 .to.equal('OVERWRITE_THIS');
             expect(mockConfig.idam.service_key)
                 .to.equal(mockConfig.secrets.probate['idam-s2s-secret']);

--- a/test/unit/testSetupSecrets.js
+++ b/test/unit/testSetupSecrets.js
@@ -43,7 +43,7 @@ describe(modulePath, () => {
             setupSecrets();
 
             expect(mockConfig.redis.password)
-                .to.equal('OVERWRITE_THIS');
+                .to.equal('dummy_password');
         });
 
         it('should only set one config value when single secret path is set', () => {
@@ -57,7 +57,7 @@ describe(modulePath, () => {
             setupSecrets();
 
             expect(mockConfig.redis.password)
-                .to.equal('OVERWRITE_THIS');
+                .to.equal('dummy_password');
             expect(mockConfig.idam.service_key)
                 .to.equal(mockConfig.secrets.probate['idam-s2s-secret']);
         });


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x No
```
