### PR TITLE
DTSPB-1159: Upgrade crossbrowser e2e dependencies and test framework.

### DIFF
--- a/bin/run-crossbrowser-tests.sh
+++ b/bin/run-crossbrowser-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+EXIT_STATUS=0
+BROWSER_GROUP=chrome yarn test-crossbrowser-e2e || EXIT_STATUS=$?
+echo EXIT_STATUS: $EXIT_STATUS
+exit $EXIT_STATUS

--- a/commit-msg.sh
+++ b/commit-msg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 COMMIT_MESSAGE=`head -n1 $1`
-PATTERN="^PRO-[0-9]+: "
+PATTERN="^(PRO|DTSPB)-[0-9]+: "
 
 if [[ ! "$COMMIT_MESSAGE" =~ $PATTERN ]]
 then

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:a11y": "NODE_ENV=testing  NODE_PATH=. LOG_LEVEL=ERROR mocha test/accessibility --reporter spec --recursive --timeout 15000 --reporter mochawesome --reporter-options reportDir=functional-output,reportFilename=a11y",
     "test-accessibility": "NODE_ENV=testing  NODE_PATH=. LOG_LEVEL=error ENABLE_TRACKING=false mocha test/accessibility --timeout 30000",
     "test-e2e": "NODE_ENV=testing  NODE_PATH=. node ./node_modules/codeceptjs/bin/codecept.js run-multiple parallel -c ./test/end-to-end/ --grep @e2e --steps --reporter mocha-multi",
-    "test-crossbrowser-e2e": "NODE_ENV=testing NODE_PATH=. codeceptjs run -c test/end-to-end/saucelabs.conf.js --steps",
+    "test-crossbrowser-e2e": "NODE_ENV=testing NODE_PATH=. codeceptjs run-multiple ${BROWSER_GROUP:-'--all'} -c test/end-to-end/saucelabs.conf.js --plugins retryFailedStep --steps --grep @e2e --reporter mocha-multi",
     "test:smoke": "NODE_ENV=testing  mocha test/smoke/healthcheck.js --timeout 30000 --reporter spec",
     "lint": "NODE_PATH=. eslint .",
     "eslint": "NODE_PATH=. eslint .",
@@ -69,6 +69,7 @@
     "csurf": "^1.10.0",
     "dateformat": "^3.0.3",
     "debug": "^4.1.1",
+    "email-validator": "^2.0.4",
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "express-urlrewrite": "^1.2.0",
@@ -94,23 +95,22 @@
     "require-directory": "^2.1.1",
     "serve-favicon": "^2.5.0",
     "uuid": "^8.3.1",
-    "validator": "^11.1.0",
-    "email-validator": "^2.0.4"
+    "validator": "^11.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "codacy-coverage": "3.2.0",
-    "codeceptjs": "^2.2.1",
+    "codeceptjs": "^2.6.11",
     "codecov": "^4.0.0-0",
     "eslint": "^6.1.0",
     "eslint-plugin-mocha": "^6.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.5.3",
-    "mocha-jenkins-reporter": "^0.4.2",
-    "mochawesome": "^4.0.1",
+    "mocha-jenkins-reporter": "^0.4.5",
     "mocha-junit-reporter": "^1.23.3",
     "mocha-multi": "^1.1.3",
+    "mochawesome": "^4.0.1",
     "nock": "^10.0.6",
     "nodemon": "^1.19.1",
     "nsp": "^3.2.1",
@@ -118,7 +118,7 @@
     "phantomjs-prebuilt": "^2.1.16",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
-    "puppeteer": "^1.19.0",
+    "puppeteer": "^5.4.1",
     "rewire": "^4.0.1",
     "selenium-standalone": "^6.16.0",
     "sinon": "^1.17.7",
@@ -134,7 +134,7 @@
     "superagent": "^5.1.0",
     "supertest": "^4.0.2",
     "watch": "^1.0.2",
-    "when": "^3.7.8",
-    "webdriverio": "^6.7.2"
+    "webdriverio": "^6.11.3",
+    "when": "^3.7.8"
   }
 }

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -1,166 +1,74 @@
+const LATEST_MAC = 'macOS 10.15';
+const LATEST_WINDOWS = 'Windows 10';
+
 const supportedBrowsers = {
-    // 'ie8': {
-    //     'browserName': 'internet explorer',
-    //     'name': 'IE_8',
-    //     'platform': 'Windows 7',
-    //     'ignoreZoomSetting': true,
-    //     'nativeEvents': false,
-    //     'ignoreProtectedModeSettings': true,
-    //     'version': '8'
-    // },
-    // 'ie9_win7': {
-    //     'browserName': 'internet explorer',
-    //     'name': 'IE9_Win7',
-    //     'platform': 'Windows 7',
-    //     'ignoreZoomSetting': true,
-    //     'nativeEvents': false,
-    //     'ignoreProtectedModeSettings': true,
-    //     'version': '9'
-    // },
-    'ie10_win7': {
-        'browserName': 'internet explorer',
-        'name': 'IE10_Win7',
-        'platform': 'Windows 7',
-        'ignoreZoomSetting': true,
-        'nativeEvents': false,
-        'ignoreProtectedModeSettings': true,
-        'version': '10'
+    microsoft: {
+        ie11_win: {
+            browserName: 'internet explorer',
+            platformName: LATEST_WINDOWS,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: IE11',
+                screenResolution: '1400x1050'
+            }
+        },
+        edge_win_latest: {
+            browserName: 'MicrosoftEdge',
+            platformName: LATEST_WINDOWS,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: Edge_Win10'
+            }
+        }
+    },
+    safari: {
+        safari_mac: {
+            browserName: 'safari',
+            platformName: 'macOS 10.14',
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: MAC_SAFARI',
+                seleniumVersion: '3.141.59',
+                screenResolution: '1400x1050'
+            }
+        }
+    },
+    chrome: {
+        chrome_win_latest: {
+            browserName: 'chrome',
+            platformName: LATEST_WINDOWS,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: WIN_CHROME_LATEST'
+            }
+        },
+        chrome_mac_latest: {
+            browserName: 'chrome',
+            platformName: LATEST_MAC,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: MAC_CHROME_LATEST'
+            }
+        }
+    },
+    firefox: {
+        firefox_win_latest: {
+            browserName: 'firefox',
+            platformName: LATEST_WINDOWS,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: WIN_FIREFOX_LATEST'
+            }
+        },
+        firefox_mac_latest: {
+            browserName: 'firefox',
+            platformName: LATEST_MAC,
+            browserVersion: 'latest',
+            'sauce:options': {
+                name: 'Probate Caveats: MAC_FIREFOX_LATEST'
+            }
+        }
     }
-    // 'ie11_win7': {
-    //     'browserName': 'internet explorer',
-    //     'name': 'IE11_Win7',
-    //     'platform': 'Windows 7',
-    //     'ignoreZoomSetting': true,
-    //     'nativeEvents': false,
-    //     'ignoreProtectedModeSettings': true,
-    //     'version': '11'
-    // },
-    // 'ie11_win8.1': {
-    //     'browserName': 'internet explorer',
-    //     'name': 'IE11_Win8.1',
-    //     'platform': 'Windows 8.1',
-    //     'ignoreZoomSetting': true,
-    //     'nativeEvents': false,
-    //     'ignoreProtectedModeSettings': true,
-    //     'version': '11'
-    // },
-    // 'ie11_win10': {
-    //     'browserName': 'internet explorer',
-    //     'name': 'IE11_Win10',
-    //     'platform': 'Windows 10',
-    //     'ignoreZoomSetting': true,
-    //     'nativeEvents': false,
-    //     'ignoreProtectedModeSettings': true,
-    //     'version': '11'
-    // },
-    // 'edge_latest': {
-    //     'browserName': 'MicrosoftEdge',
-    //     'name': 'IEEdge_LATEST',
-    //     'platform': 'Windows 10',
-    //     'version': 'latest'
-    // },
-    // 'edge_previous': {
-    //     'browserName': 'MicrosoftEdge',
-    //     'name': 'IEEdge_PREVIOUS',
-    //     'platform': 'Windows 10',
-    //     'version': 'latest-1'
-    // },
-    // 'chrome_win_latest': {
-    //     'browserName': 'chrome',
-    //     'name': 'WIN_CHROME_LATEST',
-    //     'platform': 'Windows 10',
-    //     'version': 'latest'
-    // },
-    // 'chrome_win_previous': {
-    //     'browserName': 'chrome',
-    //     'name': 'WIN_CHROME_PREVIOUS',
-    //     'platform': 'Windows 8.1',
-    //     'version': 'latest-1'
-    // },
-    // 'chrome_mac_latest': {
-    //     'browserName': 'chrome',
-    //     'name': 'MAC_CHROME_LATEST',
-    //     'platform': 'OS X 10.12',
-    //     'version': 'latest'
-    // },
-    // 'chrome_mac_previous': {
-    //     'browserName': 'chrome',
-    //     'name': 'MAC_CHROME_PREVIOUS',
-    //     'platform': 'OS X 10.11',
-    //     'version': 'latest-1'
-    // },
-    // 'firefox_win_latest': {
-    //     'browserName': 'firefox',
-    //     'name': 'WIN_FIREFOX_LATEST',
-    //     'platform': 'Windows 10',
-    //     'version': 'latest'
-    // },
-    // 'firefox_win_previous': {
-    //     'browserName': 'firefox',
-    //     'name': 'WIN_FIREFOX_PREVIOUS',
-    //     'platform': 'Windows 8.1',
-    //     'version': 'latest-1'
-    // },
-    // 'firefox_mac_latest': {
-    //     'browserName': 'firefox',
-    //     'name': 'MAC_FIREFOX_LATEST',
-    //     'platform': 'OS X 10.12',
-    //     'version': 'latest'
-    // }
-    // 'firefox_mac_previous': {
-    //     'browserName': 'firefox',
-    //     'name': 'MAC_FIREFOX_PREVIOUS',
-    //     'platform': 'OS X 10.11',
-    //     'version': 'latest-1'
-    // }
-    // 'safari9': {
-    //     'browserName': 'safari',
-    //     'name': 'SAFARI_9',
-    //     'platform': 'OS X 10.11',
-    //     'version': '9.0'
-    // },
-    // 'safari10': {
-    //     'browserName': 'safari',
-    //     'name': 'SAFARI_10',
-    //     'platform': 'OS X 10.12',
-    //     'version': '10.0'
-    // },
-    // 'iPhone6s_iOS9': {
-    //     'browserName': 'safari',
-    //     'appiumVersion': '1.6.4',
-    //     'deviceName': 'iPhone 6s Simulator',
-    //     'deviceOrientation': 'portrait',
-    //     'name': 'IPHONE6S_IOS9',
-    //     'platformVersion': '9.3',
-    //     'platformName': 'iOS'
-    // },
-    // 'iPhone7_iOS10': {
-    //     'browserName': 'safari',
-    //     'appiumVersion': '1.6.4',
-    //     'deviceName': 'iPhone 7 Simulator',
-    //     'deviceOrientation': 'portrait',
-    //     'name': 'IPHONE7_IOS10',
-    //     'platformVersion': '10.2',
-    //     'platformName': 'iOS'
-    // },
-    // 'android4-4_samsungS4': {
-    //     'browserName': 'Browser',
-    //     'appiumVersion': '1.6.4',
-    //     'deviceName': 'Samsung Galaxy S4 Emulator',
-    //     'deviceOrientation': 'portrait',
-    //     'name': 'ANDROID4-4_SAMSUNGS4',
-    //     'platformVersion': '4.4',
-    //     'platformName': 'Android'
-    // },
-    // 'android6-0_chrome': {
-    //     'browserName': 'Chrome',
-    //     'appiumVersion': '1.6.4',
-    //     'deviceName': 'Android Emulator',
-    //     'deviceOrientation': 'portrait',
-    //     'name': 'ANDROID6-0_CHROME',
-    //     'platformVersion': '6.0',
-    //     'platformName': 'Android'
-    // }
 };
 
 module.exports = supportedBrowsers;

--- a/test/end-to-end/helpers/SauceLabsReportingHelper.js
+++ b/test/end-to-end/helpers/SauceLabsReportingHelper.js
@@ -3,7 +3,8 @@ const container = require('codeceptjs').container;
 const exec = require('child_process').exec;
 
 function updateSauceLabsResult(result, sessionId) {
-    return 'curl -X PUT -s -d \'{"passed": ' + result + '}\' -u ' + process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY + ' https://saucelabs.com/rest/v1/' + process.env.SAUCE_USERNAME + '/jobs/' + sessionId;
+    console.log('SauceOnDemandSessionID=' + sessionId + ' job-name=probate-caveats-frontend');
+    return 'curl -X PUT -s -d \'{"passed": ' + result + '}\' -u ' + process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY + ' https://eu-central-1.saucelabs.com/rest/v1/' + process.env.SAUCE_USERNAME + '/jobs/' + sessionId;
 }
 
 module.exports = function() {
@@ -11,7 +12,7 @@ module.exports = function() {
     // Setting test success on SauceLabs
     event.dispatcher.on(event.test.passed, () => {
 
-        const sessionId = container.helpers('WebDriverIO').browser.requestHandler.sessionID;
+        const sessionId = container.helpers('WebDriver').browser.sessionId;
         exec(updateSauceLabsResult('true', sessionId));
 
     });
@@ -19,7 +20,7 @@ module.exports = function() {
     // Setting test failure on SauceLabs
     event.dispatcher.on(event.test.failed, () => {
 
-        const sessionId = container.helpers('WebDriverIO').browser.requestHandler.sessionID;
+        const sessionId = container.helpers('WebDriver').browser.sessionId;
         exec(updateSauceLabsResult('false', sessionId));
 
     });

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -1,58 +1,114 @@
+/* eslint-disable no-console */
+
 const supportedBrowsers = require('../crossbrowser/supportedBrowsers.js');
+const testConfig = require('config');
 
-const browser = process.env.SAUCELABS_BROWSER || 'chrome';
-const tunnelName = process.env.TUNNEL_IDENTIFIER || '';
-
-const setupConfig = {
-    'tests': './paths/*.js',
-    'output': './output',
-    'timeout': 20000,
-    'helpers': {
-        WebDriverIO: {
-            url: process.env.TEST_E2E_FRONTEND_URL || 'https://localhost:3000',
-            browser: supportedBrowsers[browser].browserName,
-            waitforTimeout: 60000,
-            cssSelectorsEnabled: 'true',
-            windowSize: '1600x900',
-            timeouts: {
-                script: 60000,
-                'page load': 60000,
-                implicit: 20000
-            },
-            'host': 'ondemand.saucelabs.com',
-            'port': 80,
-            'user': process.env.SAUCE_USERNAME,
-            'key': process.env.SAUCE_ACCESS_KEY,
-            desiredCapabilities: getDesiredCapabilities()
-        },
-
-        'JSWait': {
-            'require': './helpers/JSWait.js'
-        },
-
-        'SauceLabsReportingHelper': {
-            'require': './helpers/SauceLabsReportingHelper.js'
-        }
-    },
-    'include': {
-        'I': './pages/steps.js'
-    },
-    'mocha': {
-        'reporterOptions': {
-            'reportDir': process.env.E2E_CROSSBROWSER_OUTPUT_DIR || './functional-output',
-            'reportName': browser + '_report',
-            'reportTitle': 'Crossbrowser results for: ' + browser.toUpperCase(),
-            'inlineAssets': true
-        }
-    },
-    'name': 'frontEnd Tests'
+const waitForTimeout = parseInt(process.env.WAIT_FOR_TIMEOUT) || 45000;
+const smartWait = parseInt(process.env.SMART_WAIT) || 30000;
+const browser = process.env.BROWSER_GROUP || 'chrome';
+const defaultSauceOptions = {
+    username: process.env.SAUCE_USERNAME,
+    accessKey: process.env.SAUCE_ACCESS_KEY,
+    tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || 'reformtunnel',
+    acceptSslCerts: true,
+    windowSize: '1600x900',
+    tags: ['probate_caveats']
 };
 
-function getDesiredCapabilities() {
-    const desiredCapability = supportedBrowsers[browser];
-    desiredCapability.tunnelIdentifier = tunnelName;
-    desiredCapability.tags = ['probate'];
-    return desiredCapability;
+function merge (intoObject, fromObject) {
+    return Object.assign({}, intoObject, fromObject);
 }
+
+function getBrowserConfig(browserGroup) {
+    const browserConfig = [];
+    for (const candidateBrowser in supportedBrowsers[browserGroup]) {
+        if (candidateBrowser) {
+            const candidateCapabilities = supportedBrowsers[browserGroup][candidateBrowser];
+            candidateCapabilities['sauce:options'] = merge(
+                defaultSauceOptions, candidateCapabilities['sauce:options']
+            );
+            browserConfig.push({
+                browser: candidateCapabilities.browserName,
+                capabilities: candidateCapabilities
+            });
+        } else {
+            console.error('ERROR: supportedBrowsers.js is empty or incorrectly defined');
+        }
+    }
+    return browserConfig;
+}
+
+const setupConfig = {
+    tests: testConfig.TestPathToRun,
+    output: `${process.cwd()}/${testConfig.TestOutputDir}`,
+    helpers: {
+        WebDriver: {
+            url: testConfig.TestE2EFrontendUrl + testConfig.TestBasePath,
+            browser,
+            smartWait,
+            waitForTimeout,
+            cssSelectorsEnabled: 'true',
+            host: 'ondemand.eu-central-1.saucelabs.com',
+            port: 80,
+            region: 'eu',
+            capabilities: {}
+        },
+        SauceLabsReportingHelper: {
+            require: './helpers/SauceLabsReportingHelper.js'
+        },
+        JSWait: {
+            require: './helpers/JSWait.js'
+        }
+    },
+    plugins: {
+        retryFailedStep: {
+            enabled: true,
+            retries: 2
+        },
+        autoDelay: {
+            enabled: true,
+            delayAfter: 2000
+        }
+    },
+    include: {
+        I: './pages/steps.js'
+    },
+    mocha: {
+        reporterOptions: {
+            'codeceptjs-cli-reporter': {
+                stdout: '-',
+                options: {steps: true}
+            },
+            'mocha-junit-reporter': {
+                stdout: '-',
+                options: {mochaFile: `${testConfig.TestOutputDir}/result.xml`}
+            },
+            mochawesome: {
+                stdout: testConfig.TestOutputDir + '/console.log',
+                options: {
+                    reportDir: testConfig.TestOutputDir,
+                    reportName: 'index',
+                    reportTitle: 'Crossbrowser results for: ' + browser.toUpperCase(),
+                    inlineAssets: true
+                }
+            }
+        }
+    },
+    multiple: {
+        microsoft: {
+            browsers: getBrowserConfig('microsoft')
+        },
+        chrome: {
+            browsers: getBrowserConfig('chrome')
+        },
+        firefox: {
+            browsers: getBrowserConfig('firefox')
+        },
+        safari: {
+            browsers: getBrowserConfig('safari')
+        }
+    },
+    name: 'Probate Caveats FrontEnd Cross-Browser Tests'
+};
 
 exports.config = setupConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,18 +187,6 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@types/archiver@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-3.1.1.tgz#10cc1be44af8911e57484342c7b3b32a5f178a1a"
-  integrity sha512-TzVZ9204sH1TuFylfr1cw/AA/3/VldAAXswEwKLXUOzA9mDg+m6gHF9EaqKNlozcjc6knX5m1KAqJzksPLSEfw==
-  dependencies:
-    "@types/glob" "*"
-
-"@types/atob@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/atob/-/atob-2.1.2.tgz#157eb0cc46264a8c55f2273a836c7a1a644fb820"
-  integrity sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg==
-
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -229,21 +217,6 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
   integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
 
-"@types/fs-extra@^9.0.2":
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.4.tgz#12553138cf0438db9a31cdc8b0a3aa9332eb67aa"
-  integrity sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/glob@*":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
-  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
@@ -256,37 +229,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash.clonedeep@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
-  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.isplainobject@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#757d2dcdecbb32f4452018b285a586776092efd1"
-  integrity sha512-8G41YFhmOl8Ck6NrwLK5hhnbz6ADfuDJP+zusDnX3PoYhfC60+H/rQE6zmdO4yFzPCPJPY4oGZK2spbXm6gYEA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.merge@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
-  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.165"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
-  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
-
-"@types/minimatch@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
-
 "@types/node@*":
   version "14.0.26"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.26.tgz#22a3b8a46510da8944b67bfc27df02c34a35331c"
@@ -297,10 +239,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
-"@types/puppeteer-core@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz#3b7fbbac53d56b566f5ef096116e1d60d504aa45"
-  integrity sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==
+"@types/puppeteer-core@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz#880a7917b4ede95cbfe2d5e81a558cfcb072c0fb"
+  integrity sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==
   dependencies:
     "@types/puppeteer" "*"
 
@@ -348,16 +290,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
-"@types/ua-parser-js@^0.7.33":
-  version "0.7.33"
-  resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz#4a92089511574e12928a7cb6b99a01831acd1dd7"
-  integrity sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw==
-
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/yauzl@^2.9.1":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
@@ -374,12 +306,12 @@
     deepmerge "^4.0.0"
     glob "^7.1.2"
 
-"@wdio/config@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-6.10.0.tgz#e087cfb6d462b627ffe0caa80fea15ece589f83b"
-  integrity sha512-Wl+OzX8X1kRRE2oymqleLTQIaWkj04AGLGNpg1f3dolwelQK/5RMPG4oUnnnB1jZhkywMkAqvw/yf3u+zl/G0Q==
+"@wdio/config@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-6.11.0.tgz#ba6b0ef72d9f40bd577da16602de84390c3dcdb4"
+  integrity sha512-aNkH5sPEybOf7ND1JrAlCsKZow6KMAaY3Wyf9yHralQ3xmclmswFKU/DseP7go17Ivc2KHLl7MMkNaqVY90siw==
   dependencies:
-    "@wdio/logger" "6.8.0"
+    "@wdio/logger" "6.10.10"
     deepmerge "^4.0.0"
     glob "^7.1.2"
 
@@ -393,10 +325,10 @@
     loglevel-plugin-prefix "^0.8.4"
     strip-ansi "^6.0.0"
 
-"@wdio/logger@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-6.8.0.tgz#9b41f0538d1f178fd8f115e385fe457992cf8e8c"
-  integrity sha512-IvRnp2gTU1z6L+snMrKLrRDqYFq9yzcqXp7i6+Q/bxewxkgcpitm4hSs+13KS4fmbeBmhT5UeUeumnTZBYkhBQ==
+"@wdio/logger@6.10.10":
+  version "6.10.10"
+  resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-6.10.10.tgz#1e07cf32a69606ddb94fa9fd4b0171cb839a5980"
+  integrity sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==
   dependencies:
     chalk "^4.0.0"
     loglevel "^1.6.0"
@@ -408,10 +340,10 @@
   resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-5.22.1.tgz#51fde0acb57d4ddf07d078fef0ad9c91d227229d"
   integrity sha512-GdoWb/HTrb09Qb0S/7sLp1NU94LAhTsF1NnFj5sEFSUpecrl0S07pnhVg54pUImectN/woaqSl7uJGjlSGZcdQ==
 
-"@wdio/protocols@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-6.10.0.tgz#5f3523d77bf77fc1bcec7ee0469b8a52ef8fb499"
-  integrity sha512-MaloMFtlZeeGoqHyy2g5QM8HHuQDZOAGjxotsQ6mVAzZpAFbwUGHPSRlwBbbsB3gHVALJVowViltJ95jgaFfZg==
+"@wdio/protocols@6.10.6":
+  version "6.10.6"
+  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-6.10.6.tgz#8d1deed6651a5ca0a185ea334fc1a371dc4c700c"
+  integrity sha512-CLLVdc82S+Zij7f9djL90JC1bE5gtaOn+EF2pY4n8XdypqPUa1orQip8stQtX/wXEX0Ak45MEcSU9nCY+CzNnQ==
 
 "@wdio/repl@5.23.0":
   version "5.23.0"
@@ -420,12 +352,12 @@
   dependencies:
     "@wdio/utils" "5.23.0"
 
-"@wdio/repl@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-6.8.0.tgz#158e8ad02ccc2f1064a04d0c91b85136f4a6d99d"
-  integrity sha512-unFnItXq6+V8JNfAtPtuEza047r2dLdcFXPN4exq7+O/kPJTzsTGOAQTlSLPJGMrfy5axTk90KOl08gpJvzjOA==
+"@wdio/repl@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-6.11.0.tgz#5b1eab574b6b89f7f7c383e7295c06af23c3818e"
+  integrity sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==
   dependencies:
-    "@wdio/utils" "6.8.0"
+    "@wdio/utils" "6.11.0"
 
 "@wdio/utils@5.23.0":
   version "5.23.0"
@@ -435,12 +367,12 @@
     "@wdio/logger" "5.16.10"
     deepmerge "^4.0.0"
 
-"@wdio/utils@6.8.0":
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-6.8.0.tgz#1df85ee28bb7a42d62f96ed291ca8b721ca9f30d"
-  integrity sha512-2vGwkaqP2e876o3NDTWz021aLTBrbZfCLHETuS+e/J0IXMR3FQ8et01BY/bjwyz6EP1I3vVtP2ZVC1dV2yIIVQ==
+"@wdio/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-6.11.0.tgz#878c2500efb1a325bf5a66d2ff3d08162f976e8c"
+  integrity sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==
   dependencies:
-    "@wdio/logger" "6.8.0"
+    "@wdio/logger" "6.10.10"
 
 a-sync-waterfall@^1.0.0:
   version "1.0.1"
@@ -1666,7 +1598,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codeceptjs@^2.2.1:
+codeceptjs@^2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/codeceptjs/-/codeceptjs-2.6.11.tgz#64c8876dbb91dd1f184428ca47b8d16f9003eee4"
   integrity sha512-0MLD6Wclh+RBAJjy4Lw3UovjFylKIamkcqnb4JIudxvOWFotla2iFfTdOTNVt5Tt2BnH+pe1VHbyEhEOARKw7A==
@@ -2070,6 +2002,11 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
+css-shorthand-properties@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz#1c808e63553c283f289f2dd56fcee8f3337bd935"
+  integrity sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==
+
 css-to-xpath@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/css-to-xpath/-/css-to-xpath-0.1.0.tgz#ac0d1c26cef023f7bd8cf2e1fc1f77134bc70c47"
@@ -2373,23 +2310,25 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+devtools-protocol@0.0.809251:
+  version "0.0.809251"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.809251.tgz#300b3366be107d5c46114ecb85274173e3999518"
+  integrity sha512-pf+2OY6ghMDPjKkzSWxHMq+McD+9Ojmq5XVRYpv/kPd9sTMQxzEt21592a31API8qRjro0iYYOc3ag46qF/1FA==
+
 devtools-protocol@0.0.818844:
   version "0.0.818844"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
   integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
 
-devtools@6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.10.0.tgz#67f10e6dd6d6ae25ea0cef79d82a097c689bb1cd"
-  integrity sha512-IgnvglibbhK/hZY1kYpM4Q0yzz/EUlHNgI/jm2+a95LvqGjUVA74GGoopqZlmvXCREIGmiqdjVgDy14yeaNFAw==
+devtools@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.11.0.tgz#d20f1d1bb42357d3f2e424d7103fdd3e0d339879"
+  integrity sha512-fqiRz77IIGkHfHdIkVYIpBNKz7qllJJvHP92NKDo5e41J+sSVKsjzHsPqvYLugRhSGsZKPrJ19Sj8kmPyFi18w==
   dependencies:
-    "@types/puppeteer-core" "^2.0.0"
-    "@types/ua-parser-js" "^0.7.33"
-    "@types/uuid" "^8.3.0"
-    "@wdio/config" "6.10.0"
-    "@wdio/logger" "6.8.0"
-    "@wdio/protocols" "6.10.0"
-    "@wdio/utils" "6.8.0"
+    "@wdio/config" "6.11.0"
+    "@wdio/logger" "6.10.10"
+    "@wdio/protocols" "6.10.6"
+    "@wdio/utils" "6.11.0"
     chrome-launcher "^0.13.1"
     edge-paths "^2.1.0"
     puppeteer-core "^5.1.0"
@@ -5546,10 +5485,10 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mocha-jenkins-reporter@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.4.tgz#33d32b0480a3c1e56079a4b1ae661326a0046424"
-  integrity sha512-Orv0BVsL8HrzaoUncbYq9lTu3T5T6PjG+CoVkRDrV+wHvwz9vHAi18JeW2UBNDEnI0Ycc/ENr3fbzbThJKU+OQ==
+mocha-jenkins-reporter@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.5.tgz#d12865e0d991afbaa1d011b966195ebb8936850f"
+  integrity sha512-QoKXaxWz3gpzCBgfaqu2OZKVyibAwRTD/BF7ApMfNgafzzch9s8hMNVPTxRom9smmUAfaDfzARWKvrQMK7XACA==
   dependencies:
     diff "4.0.1"
     mkdirp "^0.5.4"
@@ -6689,7 +6628,7 @@ puppeteer-core@^5.1.0:
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
 
-puppeteer@^1.13.0, puppeteer@^1.19.0:
+puppeteer@^1.13.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.20.0.tgz#e3d267786f74e1d87cf2d15acc59177f471bbe38"
   integrity sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==
@@ -6702,6 +6641,24 @@ puppeteer@^1.13.0, puppeteer@^1.19.0:
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^6.1.0"
+
+puppeteer@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.4.1.tgz#f2038eb23a0f593ed2cce0d6e7cd5c43aecd6756"
+  integrity sha512-8u6r9tFm3gtMylU4uCry1W/CeAA8uczKMONvGvivkTsGqKA7iB7DWO2CBFYlB9GY6/IEoq9vkI5slJWzUBkwNw==
+  dependencies:
+    debug "^4.1.0"
+    devtools-protocol "0.0.809251"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^4.0.0"
+    node-fetch "^2.6.1"
+    pkg-dir "^4.2.0"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
 
 qs@6.7.0:
   version "6.7.0"
@@ -7220,15 +7177,15 @@ rewire@^4.0.1:
   dependencies:
     eslint "^4.19.1"
 
+rgb2hex@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.2.3.tgz#8aa464c517b8a26c7a79d767dabaec2b49ee78ec"
+  integrity sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==
+
 rgb2hex@^0.1.0:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.1.10.tgz#4fdd432665273e2d5900434940ceba0a04c8a8a8"
   integrity sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==
-
-rgb2hex@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.2.3.tgz#8aa464c517b8a26c7a79d767dabaec2b49ee78ec"
-  integrity sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==
 
 rimraf@2, rimraf@^2.6.1:
   version "2.7.1"
@@ -8716,16 +8673,15 @@ webdriver@5.23.0:
     lodash.merge "^4.6.1"
     request "^2.83.0"
 
-webdriver@6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-6.10.0.tgz#987f02cbd932a0d0b249f217e443fe34af1229bd"
-  integrity sha512-73WQqtLlQGXR+mJ1AWMAJ6ENR3hu0bM94uVOYx+SlzOAXucPa+VT7vMyz8IfIlLAAhN84QdIgvYY0VundDMUgA==
+webdriver@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-6.11.0.tgz#2997bf4ff6c1dcb4e58b4ae9e2b83af8b938f643"
+  integrity sha512-31uD1Vi+9QAzDSpN3+0oFFRnzJP8IVp8wRjLVbIOaQGPXV1sKjAP7v6LJcxl1JjcmW8keAIh2eyAgbjZJbcyZw==
   dependencies:
-    "@types/lodash.merge" "^4.6.6"
-    "@wdio/config" "6.10.0"
-    "@wdio/logger" "6.8.0"
-    "@wdio/protocols" "6.10.0"
-    "@wdio/utils" "6.8.0"
+    "@wdio/config" "6.11.0"
+    "@wdio/logger" "6.10.10"
+    "@wdio/protocols" "6.10.6"
+    "@wdio/utils" "6.11.0"
     got "^11.0.2"
     lodash.merge "^4.6.1"
 
@@ -8750,25 +8706,21 @@ webdriverio@^5.15.2:
     serialize-error "^5.0.0"
     webdriver "5.23.0"
 
-webdriverio@^6.7.2:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-6.10.0.tgz#bcfe81cc315c10e7f5992633fa41cb50a77a0415"
-  integrity sha512-/9rFbhNHd9zyacmgDlBiFm0OE5myy893x6Gw0+DFX8MnLDXIBL/Nsb19RnUyQCgfEED6Vs2ZE+r5m7ZbeWsvpA==
+webdriverio@^6.11.3:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-6.11.3.tgz#043bc98514d7410264fbf14991bc0546fa119779"
+  integrity sha512-yHS01H0+oz59Y+JLj/u8piLzOhtTiQSeASwb3hHF1EDuIiiK6JgGYFAqCYr26BrlzqzUOQ/9VpJj11LtcKWF/A==
   dependencies:
-    "@types/archiver" "^3.1.1"
-    "@types/atob" "^2.1.2"
-    "@types/fs-extra" "^9.0.2"
-    "@types/lodash.clonedeep" "^4.5.6"
-    "@types/lodash.isplainobject" "^4.0.6"
-    "@types/puppeteer-core" "^2.0.0"
-    "@wdio/config" "6.10.0"
-    "@wdio/logger" "6.8.0"
-    "@wdio/repl" "6.8.0"
-    "@wdio/utils" "6.8.0"
+    "@types/puppeteer-core" "^5.4.0"
+    "@wdio/config" "6.11.0"
+    "@wdio/logger" "6.10.10"
+    "@wdio/repl" "6.11.0"
+    "@wdio/utils" "6.11.0"
     archiver "^5.0.0"
     atob "^2.1.2"
+    css-shorthand-properties "^1.1.1"
     css-value "^0.0.1"
-    devtools "6.10.0"
+    devtools "6.11.0"
     fs-extra "^9.0.1"
     get-port "^5.1.1"
     grapheme-splitter "^1.0.2"
@@ -8779,9 +8731,9 @@ webdriverio@^6.7.2:
     minimatch "^3.0.4"
     puppeteer-core "^5.1.0"
     resq "^1.9.1"
-    rgb2hex "^0.2.0"
+    rgb2hex "0.2.3"
     serialize-error "^7.0.0"
-    webdriver "6.10.0"
+    webdriver "6.11.0"
 
 when@^3.7.8:
   version "3.7.8"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-1159

### Change description ###

This change upgrades crossbrowser e2e dependencies and test framework, via the following:
- upgrades CodeceptJS, Puppeteer, Webdriver and mocha-jenkins-reporter
- refactor test setup to use Webdriver helper for CodeceptJS v2.6.* compatibility
- adds "run-crossbrowser-tests.sh" test runner
- updates supportedBrowsers.js browser list
- fixes SauceLabsReportingHelper.js


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (Crossbrowser tests only)
[ ] No
```
