### PR TITLE
DTSPB-2280 - SSL protocol Fortify fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -299,7 +299,8 @@ exports.init = function(isA11yTest = false, a11yTestSession = {}, ftValue) {
         const sslDirectory = path.join(__dirname, 'app', 'resources', 'localhost-ssl');
         const sslOptions = {
             key: fs.readFileSync(path.join(sslDirectory, 'localhost.key')),
-            cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt'))
+            cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt')),
+            secureProtocol: 'TLSv1_2_method'
         };
         const server = https.createServer(sslOptions, app);
 

--- a/test/java/config/fortify-client.properties
+++ b/test/java/config/fortify-client.properties
@@ -1,1 +1,1 @@
-fortify.client.releaseId=12345
+fortify.client.releaseId=75063


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-2280

### Change description ###

- There is a critical issue for probate-frontend and probate-frontend-caveats where the explanation is given as:
The SSLv2, SSLv23, and SSLv3 protocols contain several flaws that make them insecure, so they should not be used to transmit sensitive data.

- This issue needs to be fixed so that Fortify scan step passes in the build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
